### PR TITLE
Specify registry for rocky8

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ endif
 ifeq ("$(CCP_BASEOS)", "rocky8")
         DFSET=centos
         PACKAGER=dnf
-        DOCKERBASEREGISTRY=rockylinux/rockylinux:
+        DOCKERBASEREGISTRY=docker.io/rockylinux/rockylinux:
         BASE_IMAGE_OS=8
 endif
 


### PR DESCRIPTION
Explicitly specify registry, to avoid:

``error creating build container: short-name "rockylinux/rockylinux:8" did not resolve to an alias and no unqualified-search registries are defined in "/etc/containers/registries.conf"
``